### PR TITLE
Rename menu entry, adopt module description

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -1,5 +1,5 @@
 <?php
-$this->menuSection('Hostmap')
+$this->menuSection('Host Map')
 	->setUrl('map')
 	->setIcon('globe');
 

--- a/module.info
+++ b/module.info
@@ -1,4 +1,4 @@
 Module: map
 Version: 0.0.1
 Description: Map visualization
- This is a simple map for visualization of hostsbased status information
+ This is a simple map for visualization of host based status information based on Openstreetmap.


### PR DESCRIPTION
I would prefer "Host Map" with a space in between. I've removed all "hoststatus" or "host-objects" wordings already inside the documentation.

If you merge the PR, new screenshots might be needed.