### PR TITLE
Remove sub menu icon - style guide change

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -2,8 +2,7 @@
 $section = $this->menuSection(N_('Maps'))
     ->setIcon('globe')
     ->add($this->translate('Host Map'))
-    ->setUrl('map')
-    ->setIcon('globe');
+    ->setUrl('map');
 
 // stylesheets
 $this->provideCssFile('third-party/leaflet.css');


### PR DESCRIPTION
We've discussed sub menu items a few minutes ago, and decided
to not add icons there - as no other module does it currently.

Once we re-style the menu a bit (@lippserd) we might re-add it.

Sorry for the confusion.