### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+<!-- Formatting tips:
+
+GitHub supports Markdown: https://guides.github.com/features/mastering-markdown/
+Multi-line code blocks either with three back ticks, or four space indent.
+
+```
+Stacktrace ...
+<line>
+<line>
+```
+-->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement:  the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include configuration, logs, etc. to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the problem in -->
+* Icinga Web 2 Map version (System - About):
+* Icinga Web 2 version and modules (System - About):
+* Version used (`icinga2 --version`):
+* Operating System and version:
+* Enabled features (`icinga2 feature list`):
+* Config validation (`icinga2 daemon -C`):
+


### PR DESCRIPTION
Once you merge this, users will see a Markdown template.

This helps reduce the "missing xy" level, and also ensures that users consider every little detail when reporting an issue.

The same template is used in Icinga* and the Grafana module. Please merge soon :)