### PR TITLE
Add config options for leaflet map

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -38,6 +38,9 @@ class IndexController extends ModuleActionController
             "default_lat" => '52.515855',
             "min_zoom" => "2",
             "max_zoom" => "19",
+            "max_native_zoom" => "19",
+            "tile_url" => "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+
         );
 
         /*

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -63,12 +63,32 @@ class GeneralConfigForm extends ConfigForm
         );
         $this->addElement(
             'text',
+            'map_max_native_zoom',
+            array(
+                'placeholder' => '19',
+                'label' => $this->translate('Maximum native zoom level '),
+                'description' => $this->translate('Maximum zoom level natively supported by the map'),
+                'required' => false
+            )
+        );
+        $this->addElement(
+            'text',
             'map_min_zoom',
             array(
                 'placeholder' => '2',
                 'label' => $this->translate('Minimal zoom level'),
                 'description' => $this->translate('Minimal zoom level of the map'),
                 'required' => false
+            )
+        );
+        $this->addElement(
+            'text',
+            'map_tile_url',
+            array(
+                'placeholder' => '//\{s\}.tile.openstreetmap.org/\{z\}/\{x\}/\{y\}.png',
+                'label' => $this->translate('URL for tile server'),
+                'description' => $this->translate('Escaped server url, for leaflet tilelayer'),
+                'required' => false,
             )
         );
         $this->addElement(

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -6,7 +6,9 @@
     echo 'var map_default_long = ' . (!empty($this->default_long) ? $this->default_long : "null") . ";\n";
     echo 'var map_default_lat = ' . (!empty($this->default_lat) ? $this->default_lat : "null") . ";\n";
     echo 'var map_max_zoom = ' . $this->max_zoom . ";\n";
+    echo 'var map_max_native_zoom = ' . $this->max_native_zoom . ";\n";
     echo 'var map_min_zoom = ' . $this->min_zoom . ";\n";
+    echo 'var tile_url = \'' . $this->tile_url . "';\n";
 
     echo 'var map_show_host = "' . $this->host . "\";\n";
     ?>

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -471,9 +471,10 @@
                 }
             );
 
-            var osm = L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            var osm = L.tileLayer(tile_url, {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                 subdomains: ['a', 'b', 'c'],
+                maxNativeZoom: map_max_native_zoom,
                 maxZoom: map_max_zoom,
                 minZoom: map_min_zoom
             });


### PR DESCRIPTION
* Tile url: use custom tile servers for the map. NB: the URL has
to be escaped in the form so that it can be read/written to the
ini file. TODO: add proper escaping

* Map max native zoom: With this option added one can configure
the max zoom higher than the tile sever supports, and it gets
scaled in the browser


