### PR TITLE
module.js - zoom button translation fix

### DIFF
--- a/public/js/module.js
+++ b/public/js/module.js
@@ -555,7 +555,7 @@
 
             L.control.zoom({
                     zoomInTitle: translation['btn-zoom-in'],
-                    zoomOutTitle: translation['btn-zoom-in']
+                    zoomOutTitle: translation['btn-zoom-out']
                 }
             ).addTo(cache[id].map);
 


### PR DESCRIPTION
In current version both buttons "Zoom In" and "Zoom Out" have same translation string. Now button "Zoom In" uses translation "btn-zoom-in" and "Zoom Out"  now uses "btn-zoom-out".