### PR TITLE
module.js - clusters marks with label "total_count/down_count"

### DIFF
--- a/public/js/module.js
+++ b/public/js/module.js
@@ -514,24 +514,39 @@
             cache[id].markers = new L.MarkerClusterGroup({
                 iconCreateFunction: function (cluster) {
                     var childCount = cluster_problem_count ? 0 : cluster.getChildCount();
-
+                    var childDown = cluster_problem_count ? cluster.getChildCount() : 0;
+                    
                     var states = [];
                     $.each(cluster.getAllChildMarkers(), function (id, el) {
                         states.push(el.options.state);
-
+                        
                         if (cluster_problem_count && el.options.state > 0) {
                             childCount++;
+                        }
+                        
+                        if (!cluster_problem_count && el.options.state > 0) {
+                            childDown++;
                         }
                     });
 
                     var worstState = getWorstState(states);
                     var c = ' marker-cluster-' + worstState;
 
-                    return new L.DivIcon({
-                        html: '<div><span>' + childCount + '</span></div>',
-                        className: 'marker-cluster' + c,
-                        iconSize: new L.Point(40, 40)
-                    });
+                    if (cluster_problem_count) {
+                        return new L.DivIcon({
+                            html: '<div><span>' + childCount + '</span></div>',
+                            className: 'marker-cluster' + c,
+                            iconSize: new L.Point(40, 40)
+                        });
+                    }
+                    
+                    if (!cluster_problem_count) {
+                        return new L.DivIcon({
+                            html: '<div><span>' + childCount + '/' + childDown '</span></div>',
+                            className: 'marker-cluster' + c,
+                            iconSize: new L.Point(40, 40)
+                        });
+                    }   
                 },
                 maxClusterRadius: function (zoom) {
                     return (zoom <= disable_cluster_at_zoom) ? 80 : 1; // radius in pixels


### PR DESCRIPTION
Currenlty clusters shows count of hosts in it, and there is problem with understending, when some host goes in "down" state, because the whole cluster is marked critical and you may think that all hosts goes to "down" state. Now clusters shows total number of hosts in it and number of hosts with down state ( hosts / down )