### PR TITLE
Icingadb-web for MAP module

### DIFF
--- a/application/controllers/DataController.php
+++ b/application/controllers/DataController.php
@@ -11,6 +11,7 @@ use Icinga\Module\Monitoring\DataView\DataView;
 use ipl\Orm\Model;
 use ipl\Stdlib\Filter as IplFilter;
 use ipl\Web\Filter\QueryString;
+use ipl\Sql\Expression;
 
 class DataController extends MapController
 {
@@ -52,7 +53,9 @@ class DataController extends MapController
             if ($userPreferences->has("map")) {
                 $stateType = $userPreferences->getValue("map", "stateType", $stateType);
             }
-            $objectType = strtolower($this->params->shift('objectType', 'all'));
+            $objectType = strtolower($this->params->shift('objectType',
+                $config->get('map', 'objectType', 'all')
+            ));
 
             $this->onlyProblems = (bool)$this->params->shift('problems', false);
 
@@ -74,21 +77,26 @@ class DataController extends MapController
                 }
             }
 
-            if (in_array($objectType, ['all', 'host'])) {
-                if ($this->isUsingIcingadb) {
-                    $this->addIcingadbHostsToPoints();
-                } else {
-                    $this->addHostsToPoints();
+            if (in_array($objectType, ['icingadbweb']) && $this->isUsingIcingadb) {                
+                $this->addIcingadbWebToPoints();
+            } else {           
+                if (in_array($objectType, ['all', 'host'])) {
+                    if ($this->isUsingIcingadb) {
+                        $this->addIcingadbHostsToPoints();
+                    } else {
+                        $this->addHostsToPoints();
+                    }
                 }
+
+                if (in_array($objectType, ['all', 'service'])) {
+                    if ($this->isUsingIcingadb) {
+                        $this->addIcingadbServicesToPoints();
+                    } else {
+                        $this->addServicesToPoints();
+                    }
+                }               
             }
 
-            if (in_array($objectType, ['all', 'service'])) {
-                if ($this->isUsingIcingadb) {
-                   $this->addIcingadbServicesToPoints();
-                } else {
-                    $this->addServicesToPoints();
-                }
-            }
         } catch (\Exception $e) {
             $this->points['message'] = $e->getMessage();
             $this->points['trace'] = $e->getTraceAsString();
@@ -236,6 +244,113 @@ class DataController extends MapController
                 $host['coordinates'] = explode(",", $host['coordinates']);
                 $host['icon'] = $ar['icon'];
                 $this->points['services'][$identifier] = $host;
+            }
+        }
+    }
+
+    private function addIcingadbWebToPoints()
+    {
+        $hostQuery = Host::on($this->icingadbUtils->getDb())
+            ->with(['host.state', 'service', 'service.state'])
+            ->columns([
+                'host.id',
+                'host.name',
+                'host.display_name',
+                'vars.geolocation',
+                'vars.map_icon',
+                'hosts_down_handled'          => new Expression('SUM(CASE WHEN host_state.' . $this->stateColumn . ' = 1 AND (host_state.is_handled = \'y\' OR host_state.is_reachable = \'n\') THEN 1 ELSE 0 END)'),
+                'hosts_down_unhandled'        => new Expression('SUM(CASE WHEN host_state.' . $this->stateColumn . ' = 1 AND host_state.is_handled = \'n\' AND host_state.is_reachable = \'y\' THEN 1 ELSE 0 END)'),
+                'hosts_is_acknowledged'       => new Expression('SUM(CASE WHEN host_state.is_acknowledged = \'y\' THEN 1 ELSE 0 END)'),
+                'hosts_in_downtime'           => new Expression('SUM(CASE WHEN host_state.in_downtime = \'y\' THEN 1 ELSE 0 END)'),
+                'hosts_pending'               => new Expression('SUM(CASE WHEN host_state.' . $this->stateColumn . ' = 99 THEN 1 ELSE 0 END)'),
+                'hosts_total'                 => new Expression('SUM(CASE WHEN host.id IS NOT NULL THEN 1 ELSE 0 END)'),
+                'hosts_up'                    => new Expression('SUM(CASE WHEN host_state.' . $this->stateColumn . ' = 0 THEN 1 ELSE 0 END)'),
+                'services_critical_handled'   => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 2 AND (host_service_state.is_handled = \'y\' OR host_service_state.is_reachable = \'n\') THEN 1 ELSE 0 END)'),
+                'services_critical_unhandled' => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 2 AND host_service_state.is_handled = \'n\' AND host_service_state.is_reachable = \'y\' THEN 1 ELSE 0 END)'),
+                'services_ok'                 => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 0 THEN 1 ELSE 0 END)'),
+                'services_pending'            => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 99 THEN 1 ELSE 0 END)'),
+                'services_total'              => new Expression('SUM(CASE WHEN service_id IS NOT NULL THEN 1 ELSE 0 END)'),
+                'services_unknown_handled'    => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 3 AND (host_service_state.is_handled = \'y\' OR host_service_state.is_reachable = \'n\') THEN 1 ELSE 0 END)'),
+                'services_unknown_unhandled'  => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 3 AND host_service_state.is_handled = \'n\' AND host_service_state.is_reachable = \'y\' THEN 1 ELSE 0 END)'),
+                'services_warning_handled'    => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 1 AND (host_service_state.is_handled = \'y\' OR host_service_state.is_reachable = \'n\') THEN 1 ELSE 0 END)'),
+                'services_warning_unhandled'  => new Expression('SUM(CASE WHEN host_service_state.' . $this->stateColumn . ' = 1 AND host_service_state.is_handled = \'n\' AND host_service_state.is_reachable = \'y\' THEN 1 ELSE 0 END)')
+	    ])
+            ->filter(IplFilter::like('host.vars.geolocation', '*'))
+            ->setResultSetClass(VolatileStateResults::class);
+
+        $hostQuery 
+           ->getSelectBase()
+           ->groupBy(['host.id','host.name','host.display_name','host_vars_geolocation','host_vars_map_icon']);
+
+        if ($this->filter) {
+            $hostQuery->Filter($this->filter);
+        }
+
+        if ($this->onlyProblems) {
+            $hostQuery->Filter(IplFilter::equal('service.state.is_problem', 'y'));
+        }
+
+        $this->icingadbUtils->applyRestrictions($hostQuery);
+
+        $hostQuery = $hostQuery->execute();
+        if (! $hostQuery->hasResult()) {
+            return;
+        }
+
+        foreach ($hostQuery as $row) {
+            if (! preg_match($this->coordinatePattern, $row->vars['geolocation'])) {
+                continue;
+            }
+
+            $hostname = $row->name;
+            if (! isset($this->points['hosts'][$hostname])) {
+                $host['host_name']                  = $row->name;
+                $host['host_display_name']          = $row->display_name;
+                $host['coordinates']                = $row->vars['geolocation'];
+                $host['icon']                       = $row->vars['map_icon'] ?? null;
+
+                $host['coordinates'] = explode(",", $host['coordinates']);
+
+                if ( $row->hosts_down_unhandled > 0 )  { $host['host_state'] = 1; } else { $host['host_state'] = 0; };
+                if ( $row->hosts_down_handled > 0 )    { $host['host_in_downtime'] = 1; $host['hosts_down_handled'] = 1; } else { $host['host_in_downtime'] = 0; $host['hosts_down_handled'] = 0; };
+                if ( $row->hosts_down_unhandled > 0 )  { $host['hosts_down_unhandled'] = 1; } else { $host['hosts_down_unhandled'] = 0; };
+                if ( $row->hosts_is_acknowledged > 0 ) { $host['hosts_is_acknowledged'] = 1; } else { $host['hosts_is_acknowledged'] = 0; };
+                if ( $row->hosts_in_downtime > 0 )     { $host['hosts_in_downtime'] = 1; } else { $host['hosts_in_downtime'] = 0; };
+                if ( $row->hosts_pending > 0 )         { $host['hosts_pending'] = 1; } else { $host['hosts_pending'] = 0; };
+                if ( $row->hosts_total > 0 )           { $host['hosts_total'] = 1; } else { $host['hosts_total'] = 0; };
+                if ( $row->hosts_up > 0 )              { $host['hosts_up'] = 1; } else { $host['hosts_up'] = 0; };
+
+                $host['services_critical_handled'] = $row->services_critical_handled;
+                $host['services_critical_unhandled'] = $row->services_critical_unhandled;
+                $host['services_ok'] = $row->services_ok;
+                $host['services_pending'] = $row->services_pending;
+                $host['services_total'] = $row->services_total;
+                $host['services_unknown_handled'] = $row->services_unknown_handled;
+                $host['services_unknown_unhandled'] = $row->services_unknown_unhandled;
+                $host['services_warning_handled'] = $row->services_warning_handled;
+                $host['services_warning_unhandled'] = $row->services_warning_unhandled;
+
+		        if ( $row->hosts_down_unhandled > 0 ) {
+			        $host['host_state_service'] = 2;
+		        } elseif ( $row->hosts_down_handled > 0 ) {
+			        $host['host_state_service'] = 2;
+		        } elseif ( $row->hosts_pending > 0 ) {
+			        $host['host_state_service'] = 99;
+		        } elseif ( $row->services_critical_unhandled > 0 ) {
+			        $host['host_state_service'] = 2;
+		        } elseif ( $row->services_warning_unhandled > 0 ) {
+			        $host['host_state_service'] = 1;
+		        } elseif ( $row->services_unknown_unhandled > 0 ) {
+			        $host['host_state_service'] = 3;
+		        } elseif ( $row->services_pending > 0 ) {
+			        $host['host_state_service'] = 99;
+		        } else {
+			        $host['host_state_service'] = 0;
+		        }
+
+                $host['services'] = [];
+	        
+                $this->points['hosts'][$row->name] = $host;
             }
         }
     }

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -124,6 +124,20 @@ class GeneralConfigForm extends ConfigForm
             )
         );
         $this->addElement(
+            'select',
+            'map_objectType',
+            array(
+                'label' => $this->translate('Object type'),
+                'description' => $this->translate('Object type for map'),
+                'multiOptions' => array(
+                    'all' => 'all',
+                    'host' => 'host',
+                    'service' => 'service',
+                    'icingadbweb' => 'icingadbweb'
+                ),
+            )
+        );
+        $this->addElement(
             'text',
             'map_disable_cluster_at_zoom',
             array(

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -249,7 +249,7 @@
             this.timer = this.module.icinga.timer.register(
                 this.updateAllMapData,
                 this,
-                0
+                60000
             );
             return this;
         },


### PR DESCRIPTION
The problem I’m still facing is that it takes a very long time to get results because of the large number of service objects that need to be processed. At the moment, I have 8k hosts and 280k services.
 
I also wanted to give the MAP module a bit more of the look and feel of icingadb-web.
 
I created a new objectType called ‘icingadb’

`?objectType=icingadbweb`

This will return one SQL result per host, similar to how it currently works for hostgroups in icingadb-web.
So instead of 280k + 8k SQL rows, I only get 8k of rows.
 
Now, when you click on a marker, you get this as a result:
 
<img width="663" height="307" alt="Schermafbeelding 2025-08-31 113157" src="https://github.com/user-attachments/assets/de7dbd45-c184-43db-807a-ea32761cc9df" />

<img width="689" height="324" alt="Schermafbeelding 2025-08-31 113312" src="https://github.com/user-attachments/assets/1561aa92-bd67-4f07-bad3-1237819b3877" />

Just like it is now in icingadb-web, when you click on one of the icons you get the corresponding list.
 
 
I also adjusted the symbol according to the status.

<img width="356" height="276" alt="Schermafbeelding 2025-08-31 125006" src="https://github.com/user-attachments/assets/59052cc2-38d1-4323-92e1-2378e885a384" />

No problem → host symbol, color green
Host in error → host symbol, color red
Host in downtime or acknowledged → host symbol with plug or check, color light red
Host without problems but with a service problem → service symbol, color based on the worst status (red, orange, purple, blue)
 
To also provide the option of setting the map in icingadb mode, I added a setting in the config.ini:
 
`objectType = "icingadbweb"   (opties all, host , service or icingadbweb)
` 

This way, you can set it as default to work with the new look.
 
Would this be something to consider integrating into the MAP module?
 
As I always say, I’m not a PHP developer.
If someone can improve or optimize the code, that is always welcome.
 